### PR TITLE
Fix ui and session errors

### DIFF
--- a/src/cci/server.py
+++ b/src/cci/server.py
@@ -6,6 +6,7 @@ Serves the React frontend and provides API endpoints for session data.
 
 import json
 import logging
+import mimetypes
 from datetime import datetime
 from pathlib import Path
 
@@ -18,6 +19,14 @@ from cci.watch import WatchManager
 
 # Get logger
 logger = logging.getLogger("cci.server")
+
+
+def _ensure_static_mime_types():
+    """Force correct MIME types for static assets (especially on Windows)."""
+    mimetypes.add_type("application/javascript", ".js")
+    mimetypes.add_type("text/javascript", ".js")
+    mimetypes.add_type("text/css", ".css")
+    mimetypes.add_type("image/svg+xml", ".svg")
 
 
 class SessionSummary(BaseModel):
@@ -195,6 +204,9 @@ def create_app(watch_manager: WatchManager) -> FastAPI:
         except Exception as e:
             logger.error(f"Error saving annotations for {session_id}: {e}")
             raise HTTPException(status_code=500, detail="Failed to save annotations") from e
+
+    # Ensure consistent MIME type mappings before serving static assets
+    _ensure_static_mime_types()
 
     # Serve static files (React UI)
     # The static directory should be adjacent to this file in the package

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -153,11 +153,13 @@ const JSONViewer: React.FC<{ data: any }> = ({ data }) => (
 
 const TokenBadge: React.FC<{ usage?: { input_tokens: number, output_tokens: number } }> = ({ usage }) => {
   if (!usage) return null;
+  const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+  const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
   return (
     <div className="flex gap-3 text-xs font-mono text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-700">
-      <span className="flex items-center gap-1"><span className="text-blue-600 dark:text-blue-400">In:</span> {usage.input_tokens.toLocaleString()}</span>
-      <span className="flex items-center gap-1"><span className="text-purple-600 dark:text-purple-400">Out:</span> {usage.output_tokens.toLocaleString()}</span>
-      <span className="flex items-center gap-1 text-gray-400 border-l border-gray-300 dark:border-gray-600 pl-2">Total: {(usage.input_tokens + usage.output_tokens).toLocaleString()}</span>
+      <span className="flex items-center gap-1"><span className="text-blue-600 dark:text-blue-400">In:</span> {inputTokens.toLocaleString()}</span>
+      <span className="flex items-center gap-1"><span className="text-purple-600 dark:text-purple-400">Out:</span> {outputTokens.toLocaleString()}</span>
+      <span className="flex items-center gap-1 text-gray-400 border-l border-gray-300 dark:border-gray-600 pl-2">Total: {(inputTokens + outputTokens).toLocaleString()}</span>
     </div>
   );
 };


### PR DESCRIPTION
Fix UI loading on Windows by ensuring correct MIME types for static assets and prevent `toLocaleString` errors in session details by normalizing token usage metrics.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e2b226b-bac5-4b1f-a2c0-7e1af0a37501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e2b226b-bac5-4b1f-a2c0-7e1af0a37501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Serve static assets with correct MIME types and normalize token usage to prevent UI display errors.
> 
> - **Server (FastAPI)**:
>   - Add `_ensure_static_mime_types()` and call it before mounting `StaticFiles` to force correct MIME types for `.js`, `.css`, `.svg` in `src/cci/server.py`.
> - **UI**:
>   - `ui/src/App.tsx`: Harden `TokenBadge` by safely handling non-numeric `usage` fields to avoid `toLocaleString` errors.
> - **Utils / Normalization**:
>   - `ui/src/utils.ts`: Add `normalizeUsageMetrics()` to map provider-specific usage (`input_tokens`, `output_tokens`, `prompt_tokens`, `completion_tokens`, `total_tokens`) and compute missing values.
>   - Use normalized usage in `normalizeSession()` and rename internal variable to `usageData` before normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a30ae03898d46a57309b86aea8ca144ae3deff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->