### PR TITLE
Auto load comments and requests

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -503,6 +503,22 @@ const App: React.FC = () => {
     }
   }, [selectedSessionId]);
 
+  // Auto-select the newest session once the list loads, and handle removed sessions
+  useEffect(() => {
+    if (sessionList.length === 0) {
+      if (selectedSessionId !== null) {
+        setSelectedSessionId(null);
+      }
+      setSelectedExchangeId(null);
+      return;
+    }
+
+    const hasSelection = selectedSessionId && sessionList.some(session => session.id === selectedSessionId);
+    if (!hasSelection) {
+      setSelectedSessionId(sessionList[0].id);
+    }
+  }, [sessionList, selectedSessionId]);
+
   // --- Resizing Logic ---
 
   const startResizingSessions = (e: React.MouseEvent) => {


### PR DESCRIPTION
Automatically select the first session on UI load to immediately display annotations and request details.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8f962bf-2bcb-41a5-98bc-728f0e91093d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8f962bf-2bcb-41a5-98bc-728f0e91093d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `ui/src/App.tsx` to auto-select the first session when the list loads or current selection disappears, and clear selections when no sessions exist.
> 
> - **UI** (`ui/src/App.tsx`):
>   - **Session selection behavior**:
>     - Auto-select the first/newest session when `sessionList` loads or the current selection no longer exists.
>     - Clear `selectedSessionId` and `selectedExchangeId` when `sessionList` becomes empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1daac4cf535ff1c6e8870443d73d977e93c673ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->