### PR TITLE
Rich logging output integration

### DIFF
--- a/src/cci/cli.py
+++ b/src/cci/cli.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
@@ -24,12 +23,15 @@ from cci.config import get_cert_info, load_config
 if TYPE_CHECKING:
     from cci.config import CCIConfig
     from cci.watch import WatchManager
-from cci.logger import setup_logger
+
+from cci.logger import get_console, setup_logger
 from cci.merger import merge_streams
 from cci.splitter import split_records
 from cci.storage import count_records
 
-console = Console()
+# Use the shared console from logger module for coordinated output
+# This ensures proper coordination between Live displays and logging
+console = get_console()
 
 
 @click.group()


### PR DESCRIPTION
Unify Rich `Console` instances to prevent duplicate status messages when logging and Live displays interact.

Previously, separate `Console` objects in `logger.py` (for `RichHandler`) and `cli.py` (for `console.status()`) caused Rich's Live display to be interrupted and re-rendered by log messages, leading to repeated "IDLE" status lines. By using a single shared `Console` instance, Rich can properly coordinate logging output with dynamic Live displays.

---
<a href="https://cursor.com/background-agent?bcId=bc-793d35e0-f06f-4ea8-b8e6-3aedfa78d29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-793d35e0-f06f-4ea8-b8e6-3aedfa78d29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

