### PR TITLE
Bump version to 2.0.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2025-12-22
+
+### Changed
+
+- **App icon update** - Updated `cci-icon.png` with transparent rounded corners
+  - Replaced white background corners with transparent alpha channel
+  - Updated icon to 512×512 PNG format for better visual integration
+  - Icon now displays well on both dark and light backgrounds
+- **UI screenshot** - Updated `cci-ui-screenshot.png` to reflect latest UI changes
+
 ## [2.0.0] - 2025-12-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-interceptor"
-version = "2.0.0"
+version = "2.0.1"
 description = "Intercept and analyze LLM traffic from AI coding tools"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Changes

This PR prepares for the v2.0.1 release by updating the version number and changelog.

### Version Update
- Bump version from `2.0.0` to `2.0.1` in `pyproject.toml`

### Changelog Update
Added changelog entry for version 2.0.1 documenting:
- **App icon update** - Updated `cci-icon.png` with transparent rounded corners
  - Replaced white background corners with transparent alpha channel
  - Updated icon to 512×512 PNG format for better visual integration
  - Icon now displays well on both dark and light backgrounds
- **UI screenshot** - Updated `cci-ui-screenshot.png` to reflect latest UI changes

This release includes the icon improvements merged in #23.