### PR TITLE
feat: use OS-specific standard directories for trace logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ lli watch
 ╰─────────────────────────╯
 
   Proxy Port:    9090
-  Output Dir:    ./traces
+  Output Dir:    ./traces (or OS-specific logs directory)
   Global Log:    traces/all_captured_20251203_220000.jsonl
 
 Configure your application:
@@ -187,9 +187,9 @@ Start watch mode for continuous session capture (recommended).
 lli watch [OPTIONS]
 
 Options:
-  -p, --port INTEGER       Proxy server port (default: 9090)
-  -o, --output-dir PATH    Root output directory (default: ./traces)
-  -i, --include TEXT       Additional URL patterns to include (glob pattern)
+  -p, --port INTEGER           Proxy server port (default: 9090)
+  -o, --output-dir, --log-dir PATH  Root output directory (default: ./traces or OS log dir)
+  -i, --include TEXT           Additional URL patterns to include (glob pattern)
   --debug                  Enable debug mode with verbose logging
 ```
 

--- a/src/cci/app.py
+++ b/src/cci/app.py
@@ -6,15 +6,15 @@ from typing import Any
 
 import streamlit as st
 
+from cci.config import get_default_trace_dir
+
 # ================= 1. Config & Utils =================
 
 # Set page config first
 st.set_page_config(layout="wide", page_title="LLM Interceptor", page_icon="🔍")
 
-# Determine BASE_DIR relative to the project root
-# Assuming this script is in src/cci/app.py and traces is in project root
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-BASE_DIR = PROJECT_ROOT / "traces"
+# Determine BASE_DIR using the standard logic
+BASE_DIR = get_default_trace_dir()
 
 
 def parse_file_info(filename: str) -> tuple[int | None, str | None, str | None]:

--- a/src/cci/cli.py
+++ b/src/cci/cli.py
@@ -19,7 +19,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from cci import __version__
-from cci.config import get_cert_info, load_config
+from cci.config import get_cert_info, get_default_trace_dir, load_config
 
 if TYPE_CHECKING:
     from cci.config import CCIConfig
@@ -377,10 +377,11 @@ def stats(file: str) -> None:
 )
 @click.option(
     "--output-dir",
+    "--log-dir",
     "-o",
+    "output_dir",
     type=click.Path(),
-    default="./traces",
-    help="Root output directory (default: ./traces)",
+    help="Root output directory (default: ./traces or OS-specific logs dir)",
 )
 @click.option(
     "--include",
@@ -450,6 +451,10 @@ def watch(
 
     if debug:
         config.logging.level = "DEBUG"
+
+    # Determine output directory
+    if output_dir is None:
+        output_dir = str(get_default_trace_dir())
 
     # Setup logging
     setup_logger(config.logging.level, config.logging.log_file)

--- a/src/cci/config.py
+++ b/src/cci/config.py
@@ -223,3 +223,41 @@ def get_cert_info() -> dict[str, Any]:
         "exists": cert_path.exists(),
         "mitmproxy_dir": str(cert_path.parent),
     }
+
+
+def get_default_trace_dir() -> Path:
+    """
+    Get the default directory for trace logs.
+
+    Priority:
+    1. ./traces (if it exists)
+    2. OS-specific standard directories:
+       - Windows: %LOCALAPPDATA%\\llm-interceptor\traces
+       - macOS: ~/Library/Logs/llm-interceptor
+       - Linux: ~/.cache/llm-interceptor
+    """
+    # 1. Check if we are in the project root or current dir has traces/
+    local_traces = Path.cwd() / "traces"
+    if local_traces.is_dir():
+        return local_traces
+
+    # 2. OS-specific standard directories
+    if sys.platform == "win32":
+        # Windows: C:\Users\<User>\AppData\Local\llm-interceptor\traces
+        app_data = os.environ.get("LOCALAPPDATA")
+        if app_data:
+            base = Path(app_data)
+        else:
+            base = Path.home() / "AppData" / "Local"
+        return base / "llm-interceptor" / "traces"
+    elif sys.platform == "darwin":
+        # macOS: ~/Library/Logs/llm-interceptor
+        return Path.home() / "Library" / "Logs" / "llm-interceptor"
+    else:
+        # Linux: ~/.cache/llm-interceptor
+        cache_home = os.environ.get("XDG_CACHE_HOME")
+        if cache_home:
+            base = Path(cache_home)
+        else:
+            base = Path.home() / ".cache"
+        return base / "llm-interceptor"

--- a/src/cci/watch.py
+++ b/src/cci/watch.py
@@ -16,6 +16,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, TextIO
 
+from cci.config import get_default_trace_dir
 from cci.logger import get_logger
 
 
@@ -201,15 +202,15 @@ class WatchManager:
     - Session data extraction and processing
     """
 
-    def __init__(self, output_dir: str | Path = "./traces", port: int = 9090):
+    def __init__(self, output_dir: str | Path | None = None, port: int = 9090):
         """
         Initialize the watch manager.
 
         Args:
-            output_dir: Root directory for all output files
+            output_dir: Root directory for all output files (default: auto-detected)
             port: Proxy server port
         """
-        self.output_dir = Path(output_dir)
+        self.output_dir = Path(output_dir) if output_dir else get_default_trace_dir()
         self.port = port
         self._logger = get_logger()
 


### PR DESCRIPTION
This PR implements dynamic log directory selection using OS-specific standard paths (AppData/Library Logs/cache) while maintaining backward compatibility with the local './traces' directory. It also adds the '--log-dir' alias for '--output-dir' in the CLI.