### PR TITLE
feat: add copy buttons to System interface and Tools interface

### DIFF
--- a/ui/src/components/layout/ExchangeDetailsPane.tsx
+++ b/ui/src/components/layout/ExchangeDetailsPane.tsx
@@ -186,11 +186,19 @@ export const ExchangeDetailsPane: React.FC<{
             {activeTab === 'system' && (
               <div className="max-w-4xl mx-auto">
                 <div className="bg-white dark:bg-[#0d1117] border border-gray-200 dark:border-slate-800 rounded-lg overflow-hidden shadow-xl">
-                  <div className="px-4 py-3 bg-gray-100 dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800 flex items-center gap-2">
-                    <Terminal size={16} className="text-red-500 dark:text-red-400" />
-                    <span className="text-sm font-bold text-slate-700 dark:text-slate-300">
-                      System Instruction
-                    </span>
+                  <div className="px-4 py-3 bg-gray-100 dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800 flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Terminal size={16} className="text-red-500 dark:text-red-400" />
+                      <span className="text-sm font-bold text-slate-700 dark:text-slate-300">
+                        System Instruction
+                      </span>
+                    </div>
+                    {currentExchange.systemPrompt && (
+                      <CopyButton
+                        content={currentExchange.systemPrompt}
+                        className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700"
+                      />
+                    )}
                   </div>
                   <div className="p-6 overflow-x-auto bg-gray-50 dark:bg-transparent">
                     {currentExchange.systemPrompt ? (

--- a/ui/src/components/tools/ToolsList.tsx
+++ b/ui/src/components/tools/ToolsList.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, ChevronDown, ChevronRight, Code } from 'lucide-react';
 import type { NormalizedTool } from '../../types';
 import { JSONViewer } from '../common/JSONViewer';
+import { CopyButton } from '../common/CopyButton';
 
 // Tools list with sticky header support
 export const ToolsList: React.FC<{
@@ -183,15 +184,32 @@ const ToolDefinitionControlled = React.forwardRef<
       {expanded && (
         <div className="tool-content p-4 border-t border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-black/20">
           {tool.description && (
-            <div className="mb-4 text-sm text-slate-600 dark:text-gray-400 italic bg-white dark:bg-slate-900 p-3 rounded border-l-2 border-gray-300 dark:border-gray-700 whitespace-pre-wrap break-words">
-              {tool.description}
+            <div className="mb-4 group/desc">
+              <div className="text-[10px] font-bold text-gray-500 mb-2 uppercase tracking-wide flex items-center justify-between">
+                <span>Description</span>
+                <CopyButton
+                  content={tool.description}
+                  className="opacity-0 group-hover/desc:opacity-100 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-800"
+                />
+              </div>
+              <div className="text-sm text-slate-600 dark:text-gray-400 italic bg-white dark:bg-slate-900 p-3 rounded border-l-2 border-gray-300 dark:border-gray-700 whitespace-pre-wrap break-words">
+                {tool.description}
+              </div>
             </div>
           )}
-          <div className="text-[10px] font-bold text-gray-500 mb-2 uppercase tracking-wide flex items-center gap-2">
-            <Code size={12} />
-            Input Schema
+          <div className="group/schema">
+            <div className="text-[10px] font-bold text-gray-500 mb-2 uppercase tracking-wide flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Code size={12} />
+                Input Schema
+              </div>
+              <CopyButton
+                content={JSON.stringify(tool.input_schema, null, 2)}
+                className="opacity-0 group-hover/schema:opacity-100 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-800"
+              />
+            </div>
+            <JSONViewer data={tool.input_schema} />
           </div>
-          <JSONViewer data={tool.input_schema} />
         </div>
       )}
     </div>


### PR DESCRIPTION
Added copy buttons to the following locations in the UI:
1. System interface (System tab in ExchangeDetailsPane)
2. Tool descriptions (Tools tab)
3. Tool Input Schemas (Tools tab)

The buttons follow the existing style and only appear on hover where appropriate.