### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-01-05
+
+### Added
+
+- **Copy buttons** - Added "Copy" functionality to System and Tools interfaces for easier content extraction
+- **OS-specific trace directories** - Now uses standard system directories for trace logs (XDG on Linux, Library/Logs on macOS, LocalAppData on Windows)
+- **Watch mode for development** - Added auto-rebuild watch mode for UI development
+
+### Fixed
+
+- **Session naming & UI title** - Improved session naming logic and fixed UI title display issues
+- **Session leakage & collisions** - Fixed session ID collisions and potential session leakage in watch mode
+
 ## [2.1.0] - 2025-12-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-interceptor"
-version = "2.1.0"
+version = "2.2.0"
 description = "Intercept and analyze LLM traffic from AI coding tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/cci/__init__.py
+++ b/src/cci/__init__.py
@@ -7,5 +7,5 @@ Note: The import package name `cci` is kept for backward compatibility.
 New code should prefer `llm_interceptor`.
 """
 
-__version__ = "1.4.0"
+__version__ = "2.2.0"
 __author__ = "LLM Interceptor Team"


### PR DESCRIPTION
This PR bumps the version to 2.2.0 and updates the changelog with the latest changes since v2.1.0.

### Changes:
- Version bump to 2.2.0 in `pyproject.toml` and `src/cci/__init__.py`.
- Updated `CHANGELOG.md` with:
    - **Added**: Copy buttons for System/Tools interfaces, OS-specific trace directories, and UI development watch mode.
    - **Fixed**: Session naming/UI title display, and session leakage/collisions in watch mode.