### PR TITLE
feat: make ui host and port configurable

### DIFF
--- a/src/cci/cli.py
+++ b/src/cci/cli.py
@@ -400,6 +400,19 @@ def stats(file: str) -> None:
     default=True,
     help="Launch the web UI (default: True)",
 )
+@click.option(
+    "--ui-host",
+    default="127.0.0.1",
+    show_default=True,
+    help="Host interface for the web UI (use 0.0.0.0 to expose on the network)",
+)
+@click.option(
+    "--ui-port",
+    default=8000,
+    show_default=True,
+    type=int,
+    help="Port for the web UI",
+)
 @click.pass_context
 def watch(
     ctx: click.Context,
@@ -408,6 +421,8 @@ def watch(
     include: tuple[str, ...],
     debug: bool,
     ui: bool,
+    ui_host: str,
+    ui_port: int,
 ) -> None:
     """
     Start watch mode for continuous session capture.
@@ -475,9 +490,6 @@ def watch(
     if ui:
         from cci.server import run_server
 
-        ui_host = "127.0.0.1"
-        ui_port = 8000  # TODO: Make configurable
-
         if _is_port_in_use(ui_host, ui_port):
             ui_url = f"http://{ui_host}:{ui_port}"
             console.print(
@@ -493,7 +505,7 @@ def watch(
             server_thread = threading.Thread(
                 target=run_server,
                 args=(watch_manager,),
-                kwargs={"port": ui_port},
+                kwargs={"host": ui_host, "port": ui_port},
                 daemon=True,
             )
             server_thread.start()

--- a/ui/README.md
+++ b/ui/README.md
@@ -23,6 +23,11 @@ This UI is bundled with the `llm-interceptor` Python package.
     lli watch --include "*example.com*"
     ```
 
+    To expose the UI on your network:
+    ```bash
+    lli watch --ui-host 0.0.0.0 --ui-port 8000
+    ```
+
 2.  **Open the Dashboard**:
     The CLI will print a URL (usually `http://localhost:8000`). Click it to open the dashboard.
 


### PR DESCRIPTION
## Summary
- add --ui-host/--ui-port flags for the web UI
- pass configured host/port to the UI server bind
- document network-exposed UI usage

## Testing
- not run (cli-only change)