### PR TITLE
feat: improve request visibility in proxy logs

### DIFF
--- a/src/cci/logger.py
+++ b/src/cci/logger.py
@@ -67,6 +67,7 @@ def setup_logger(
         console=console,
         show_time=True,
         show_path=False,
+        show_level=False,
         rich_tracebacks=True,
         tracebacks_show_locals=level.upper() == "DEBUG",
         markup=True,
@@ -115,9 +116,16 @@ def log_request_summary(
     url: str,
     status: int | None = None,
     latency_ms: float | None = None,
+    captured: bool = True,
 ) -> None:
     """Log a formatted request summary."""
     logger = get_logger()
+
+    # Capture status indicator
+    if captured:
+        cap_str = "[bold green][CAPT][/bold green]"
+    else:
+        cap_str = "[bold magenta][SKIP][/bold magenta]"
 
     # Color coding based on status
     if status is None:
@@ -131,7 +139,7 @@ def log_request_summary(
 
     latency_str = f" ({latency_ms:.0f}ms)" if latency_ms else ""
 
-    logger.info(f"{method} {url} {status_str}{latency_str}")
+    logger.info(f"{cap_str} {method} {url} {status_str}{latency_str}")
 
 
 def log_streaming_progress(request_id: str, chunk_count: int) -> None:


### PR DESCRIPTION
This PR improves the visibility of intercepted requests in the proxy logs.

### Key Changes:
- **Comprehensive Logging**: Log a summary for all requests, including those skipped by the URL filter.
- **Visual Indicators**: Added `[CAPT]` (green) and `[SKIP]` (magenta) prefixes to log entries to clearly show capture status.
- **Cleaner Logs**: Set `show_level=False` in `setup_logger` to reduce terminal noise.
- **Latency Tracking**: Ensured latency and status codes are logged for all responses handled by the proxy.

This makes it much easier to debug which requests are being matched by filters during local development.