### PR TITLE
Add LAN capture mode (--lan)

### DIFF
--- a/src/cci/net.py
+++ b/src/cci/net.py
@@ -12,11 +12,6 @@ import ipaddress
 import socket
 
 
-def is_wildcard_host(host: str) -> bool:
-    """Return True if host is a wildcard bind address (IPv4/IPv6)."""
-    return host in {"0.0.0.0", "::", "[::]"}
-
-
 def _is_publicly_unhelpful(ip: str) -> bool:
     """Return True if the ip is loopback/unspecified/link-local."""
     try:
@@ -65,20 +60,14 @@ def detect_primary_ipv4() -> str | None:
     return None
 
 
-def get_advertise_host(listen_host: str, explicit_advertise_host: str | None = None) -> str:
+def reachable_host_for_listen_host(listen_host: str) -> str:
     """
-    Return the best host to show users for connecting to a service.
+    Return a "reachable" host string to show users.
 
-    - If explicit_advertise_host is provided, it wins.
-    - If listen_host is wildcard, attempt to detect a LAN IP.
+    - When listening on 0.0.0.0 (all interfaces), return the detected LAN IPv4.
     - Otherwise return listen_host as-is.
     """
-    if explicit_advertise_host:
-        return explicit_advertise_host
-
-    if is_wildcard_host(listen_host):
-        detected = detect_primary_ipv4()
-        return detected or "127.0.0.1"
-
+    if listen_host == "0.0.0.0":
+        return detect_primary_ipv4() or "127.0.0.1"
     return listen_host
 


### PR DESCRIPTION
Add `--lan`, `--proxy-host`, and `--advertise-host` options to `lli watch` to enable LAN proxy capture with automatic local IP detection and improved proxy instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ca7af28-7d8c-42ad-9e74-560b1c267b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ca7af28-7d8c-42ad-9e74-560b1c267b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

