### PR TITLE
Add manual semantic-release GitHub Actions workflow

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,30 @@
+name: Semantic Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install python-semantic-release
+        run: pip install python-semantic-release
+
+      - name: Release version
+        run: semantic-release version
+
+      - name: Publish release
+        run: semantic-release publish


### PR DESCRIPTION
### Motivation

- Provide a manual-only GitHub Actions workflow to automate versioning, changelog updates, tagging, and GitHub Releases using `python-semantic-release`.
- Ensure releases are performed intentionally by restricting the trigger to `workflow_dispatch` only.
- Allow the workflow to create tags and releases by granting `contents: write` permission.

### Description

- Add `.github/workflows/semantic-release.yml` that runs on the `workflow_dispatch` trigger only.
- Use `actions/checkout@v4` with `fetch-depth: 0` and `actions/setup-python@v5` (Python 3.11) to prepare the environment.
- Install `python-semantic-release` via `pip install python-semantic-release` and run `semantic-release version` followed by `semantic-release publish`.
- Set workflow permissions to `contents: write` to enable committing changelog updates, tagging, and creating GitHub Releases.

### Testing

- No automated tests were run for this change because it only adds a GitHub Actions workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966301f35c48325a4ad92e6418db424)