### PR TITLE
Prepare 2.3.1 release: bump version, fix changelog classification, and update date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-01-22
+
+### Added
+
+- **LAN capture mode** - Added `--lan` flag to enable LAN capture mode
+- **Semantic release workflow** - Added automated semantic release workflow
+
+### Fixed
+
+- **Session request count attribute** - Track request count per session
+
 ## [2.3.0] - 2026-01-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-interceptor"
-version = "2.3.0"
+version = "2.3.1"
 description = "Intercept and analyze LLM traffic from AI coding tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/cci/__init__.py
+++ b/src/cci/__init__.py
@@ -7,5 +7,5 @@ Note: The import package name `cci` is kept for backward compatibility.
 New code should prefer `llm_interceptor`.
 """
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __author__ = "LLM Interceptor Team"


### PR DESCRIPTION
### Motivation

- Prepare and document the `2.3.1` patch release and correct changelog metadata, including the classification of a change and the release date.

### Description

- Updated `CHANGELOG.md` to move the **Session request count attribute** entry into the `### Fixed` section for `## [2.3.1] - 2026-01-22` and set the release date to `2026-01-22`.
- Bumped the package version to `2.3.1` in `pyproject.toml` by setting `version = "2.3.1"`.
- Updated the legacy version constant `__version__` to `"2.3.1"` in `src/cci/__init__.py`.

### Testing

- No automated tests were run for these documentation and metadata changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e04dc72c83259bf87445be99dfe6)