### PR TITLE
feat: add token usage for per request view

### DIFF
--- a/ui/src/components/common/TokenBadge.tsx
+++ b/ui/src/components/common/TokenBadge.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 export const TokenBadge: React.FC<{
-  usage?: { input_tokens: number; output_tokens: number };
+  usage?: { input_tokens: number; output_tokens: number; total_tokens: number };
 }> = ({ usage }) => {
   if (!usage) return null;
   const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
   const outputTokens =
     typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+  const totalTokens = typeof usage.total_tokens === 'number' ? usage.total_tokens : (inputTokens + outputTokens);
   return (
     <div className="flex gap-3 text-xs font-mono text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-700">
       <span className="flex items-center gap-1">
@@ -18,7 +19,7 @@ export const TokenBadge: React.FC<{
         {outputTokens.toLocaleString()}
       </span>
       <span className="flex items-center gap-1 text-gray-400 border-l border-gray-300 dark:border-gray-600 pl-2">
-        Total: {(inputTokens + outputTokens).toLocaleString()}
+        Total: {totalTokens.toLocaleString()}
       </span>
     </div>
   );

--- a/ui/src/components/layout/RequestsPane.tsx
+++ b/ui/src/components/layout/RequestsPane.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useCallback, useMemo, memo } from 'react';
+import React, { useState, useCallback, useMemo, useRef, memo } from 'react';
 import {
   Check,
   ChevronLeft,
   ChevronRight,
   Clock,
+  Coins,
   Cpu,
   Filter,
   MessageCircle,
@@ -365,6 +366,9 @@ const RequestItem = React.memo<{
             </span>
           </div>
           <div className="flex items-center gap-1.5">
+            {exchange.usage && (
+              <TokenUsageInline usage={exchange.usage} isSelected={isSelected} />
+            )}
             {exchange.latencyMs > 0 && (
               <span className={`${isSelected ? 'dark:text-slate-300' : 'text-slate-500 dark:text-slate-600'}`}>
                 {(exchange.latencyMs / 1000).toFixed(2)}s
@@ -429,3 +433,60 @@ const RequestItem = React.memo<{
     </div>
   );
 });
+
+// Inline token usage display with hover tooltip showing breakdown
+const TokenUsageInline: React.FC<{
+  usage: { input_tokens: number; output_tokens: number; total_tokens: number };
+  isSelected: boolean;
+}> = ({ usage, isSelected }) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+  const ref = useRef<HTMLSpanElement>(null);
+
+  const handleMouseEnter = (e: React.MouseEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setTooltipPos({ x: rect.left, y: rect.bottom + 4 });
+    setShowTooltip(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowTooltip(false);
+  };
+
+  return (
+    <span
+      ref={ref}
+      className={`relative flex items-center gap-0.5 cursor-default font-mono px-1 rounded ${
+        isSelected
+          ? 'text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-900/20'
+          : 'text-cyan-600 dark:text-cyan-500 bg-cyan-50 dark:bg-cyan-900/10'
+      }`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Coins size={9} />
+      <span>{usage.total_tokens.toLocaleString()}</span>
+      {showTooltip && (
+        <div
+          className="fixed z-50 p-2.5 text-xs bg-slate-900 dark:bg-slate-700 text-white rounded-lg shadow-xl whitespace-nowrap font-mono"
+          style={{ left: tooltipPos.x, top: tooltipPos.y }}
+        >
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-blue-300">Prompt Tokens:</span>
+              <span className="font-bold">{usage.input_tokens.toLocaleString()}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-purple-300">Completion Tokens:</span>
+              <span className="font-bold">{usage.output_tokens.toLocaleString()}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4 border-t border-slate-600 pt-1.5">
+              <span className="text-cyan-300">Total Tokens:</span>
+              <span className="font-bold">{usage.total_tokens.toLocaleString()}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </span>
+  );
+};

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -87,6 +87,7 @@ export interface NormalizedExchange {
   usage?: {
     input_tokens: number;
     output_tokens: number;
+    total_tokens: number;
   };
 
   // Original raw data for debugging

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -79,9 +79,14 @@ const normalizeUsageMetrics = (rawUsage: unknown) => {
     output = Math.max(total - input, 0);
   }
 
+  const inputFinal = input ?? total ?? 0;
+  const outputFinal = output ?? 0;
+  const totalFinal = total ?? (inputFinal + outputFinal);
+
   return {
-    input_tokens: input ?? total ?? 0,
-    output_tokens: output ?? 0,
+    input_tokens: inputFinal,
+    output_tokens: outputFinal,
+    total_tokens: totalFinal,
   };
 };
 


### PR DESCRIPTION
Display token consumption for each request, showing total tokens with a detailed breakdown on hover, supporting OpenAI and Anthropic formats.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ec3d6b73-ac29-4bf8-9ecb-79a09cc7754b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec3d6b73-ac29-4bf8-9ecb-79a09cc7754b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

