### PR TITLE
feat(ui): add delete session action with backend removal and confirmation

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -35,9 +35,10 @@ const App: React.FC = () => {
     setSelectedSessionId,
     selectedExchangeId,
     setSelectedExchangeId,
+    deleteSession,
   } = useSessions({ apiBase: API_BASE, pollMs: 2000 });
 
-  const { annotations, ensureLoaded, fetchAllAnnotations, updateSessionNote, updateRequestNote } = useAnnotations({
+  const { annotations, setAnnotations, ensureLoaded, fetchAllAnnotations, updateSessionNote, updateRequestNote } = useAnnotations({
     apiBase: API_BASE,
   });
 
@@ -73,6 +74,19 @@ const App: React.FC = () => {
     [currentSession, selectedExchangeId]
   );
 
+  const handleDeleteSession = async (sessionId: string) => {
+    const deleted = await deleteSession(sessionId);
+    if (deleted) {
+      setAnnotations((prev) => {
+        const next = { ...prev };
+        delete next[sessionId];
+        return next;
+      });
+    }
+
+    return deleted;
+  };
+
   return (
     <div
       className={`${
@@ -95,6 +109,7 @@ const App: React.FC = () => {
             onToggleTheme={toggleTheme}
             annotations={annotations}
             onUpdateSessionNote={updateSessionNote}
+            onDeleteSession={handleDeleteSession}
           />
 
           <MemoizedRequestsPane

--- a/ui/src/components/layout/SessionsSidebar.tsx
+++ b/ui/src/components/layout/SessionsSidebar.tsx
@@ -9,6 +9,7 @@ import {
   Moon,
   Pencil,
   Sun,
+  Trash2,
 } from 'lucide-react';
 import type { AnnotationData, SessionSummary } from '../../types';
 import { formatTimestamp } from '../../utils';
@@ -29,6 +30,7 @@ export const SessionsSidebar: React.FC<{
 
   annotations: Record<string, AnnotationData>;
   onUpdateSessionNote: (sessionId: string, note: string) => void;
+  onDeleteSession: (sessionId: string) => Promise<boolean>;
 }> = ({
   width,
   isCollapsed,
@@ -41,6 +43,7 @@ export const SessionsSidebar: React.FC<{
   onToggleTheme,
   annotations,
   onUpdateSessionNote,
+  onDeleteSession,
 }) => {
   const [editingSessionNote, setEditingSessionNote] = useState<string | null>(null);
 
@@ -70,6 +73,7 @@ export const SessionsSidebar: React.FC<{
           onSetIsCollapsed={setIsCollapsed}
           onSetEditingSessionNote={setEditingSessionNote}
           onUpdateSessionNote={onUpdateSessionNote}
+          onDeleteSession={onDeleteSession}
         />
       );
     });
@@ -82,6 +86,7 @@ export const SessionsSidebar: React.FC<{
     onSelectSession,
     setIsCollapsed,
     onUpdateSessionNote,
+    onDeleteSession,
   ]);
 
   return (
@@ -155,6 +160,7 @@ const SessionItem = React.memo<{
   onSetIsCollapsed: (collapsed: boolean) => void;
   onSetEditingSessionNote: (sessionId: string | null) => void;
   onUpdateSessionNote: (sessionId: string, note: string) => void;
+  onDeleteSession: (sessionId: string) => Promise<boolean>;
 }>(({
   session,
   isCollapsed,
@@ -166,6 +172,7 @@ const SessionItem = React.memo<{
   onSetIsCollapsed,
   onSetEditingSessionNote,
   onUpdateSessionNote,
+  onDeleteSession,
 }) => {
   const handleSelectSession = useCallback(() => {
     onSelectSession(session.id);
@@ -196,6 +203,16 @@ const SessionItem = React.memo<{
   const handleEditNote = useCallback(() => {
     onSetEditingSessionNote(session.id);
   }, [session.id, onSetEditingSessionNote]);
+
+  const handleDeleteSession = useCallback(async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    const confirmed = window.confirm(`Delete ${session.id}? This will remove local files and cannot be undone.`);
+    if (!confirmed) {
+      return;
+    }
+
+    await onDeleteSession(session.id);
+  }, [session.id, onDeleteSession]);
 
   return (
     <div>
@@ -235,6 +252,14 @@ const SessionItem = React.memo<{
                 type="button"
               >
                 <Pencil size={12} className="text-slate-500 dark:text-slate-300" />
+              </button>
+              <button
+                onClick={handleDeleteSession}
+                className="p-1.5 bg-white dark:bg-slate-700 rounded shadow-sm hover:scale-110"
+                title="Delete session"
+                type="button"
+              >
+                <Trash2 size={12} className="text-red-500 dark:text-red-400" />
               </button>
             </div>
 


### PR DESCRIPTION
### Motivation
- Provide a way for users to remove a captured session from the left Sessions list that also deletes the local files for that session and immediately refreshes the UI.
- Prevent accidental data loss by showing a confirmation prompt before performing the destructive action.

### Description
- Add backend API `DELETE /api/sessions/{session_id}` which validates the session directory and removes it with `shutil.rmtree` returning `{"ok": true}` on success (file: `src/cci/server.py`).
- Add a delete icon (`Trash2`) to each expanded session row in the left sidebar and a click handler that shows `window.confirm` before calling the deletion flow (file: `ui/src/components/layout/SessionsSidebar.tsx`).
- Expose `deleteSession` from `useSessions` which calls the backend delete endpoint and updates local session state (`sessionList`, `currentSession`, selection) so the UI refreshes immediately (file: `ui/src/hooks/useSessions.ts`).
- Wire a top-level `handleDeleteSession` in `App` to call `deleteSession` and remove cached annotations for the deleted session to avoid stale UI state (file: `ui/src/App.tsx`).

### Testing
- Ran unit tests with `PYTHONPATH=src python -m pytest -q` and all tests passed (`63 passed`).
- Built the frontend with `npm run build` in `ui/` which completed successfully.
- Ran linter with `npm run lint` in `ui/` which reported pre-existing `ExchangeDetailsPane.tsx` memoization lint errors not introduced by this change and is therefore unrelated to the deletion feature.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c76347908325adb7ad467ebfd719)