### PR TITLE
fix: use numeric sorting for request/exchange IDs instead of lexicographic

### DIFF
--- a/src/lli/app.py
+++ b/src/lli/app.py
@@ -47,7 +47,7 @@ def load_session_turns(session_path: Path) -> list[dict[str, Any]]:
 
     files = sorted(
         os.listdir(target_dir),
-        key=lambda f: int(f.split("_")[0]) if f.split("_")[0].isdigit() else f,
+        key=lambda f: (0, int(f.split("_")[0])) if f.split("_")[0].isdigit() else (1, f),
     )
     turns_map: dict[int, dict[str, Any]] = {}
 

--- a/src/lli/app.py
+++ b/src/lli/app.py
@@ -45,7 +45,10 @@ def load_session_turns(session_path: Path) -> list[dict[str, Any]]:
     if not target_dir.exists():
         return []
 
-    files = sorted(os.listdir(target_dir))
+    files = sorted(
+        os.listdir(target_dir),
+        key=lambda f: int(f.split("_")[0]) if f.split("_")[0].isdigit() else f,
+    )
     turns_map: dict[int, dict[str, Any]] = {}
 
     for f in files:

--- a/src/lli/merger.py
+++ b/src/lli/merger.py
@@ -120,7 +120,10 @@ class StreamMerger:
                     writer.write_record(request)
 
                     request_chunks = sorted(
-                        chunks[request_id], key=lambda x: x.get("chunk_index", 0)
+                        chunks[request_id],
+                        key=lambda x: int(x.get("chunk_index", 0))
+                        if isinstance(x.get("chunk_index"), (int, float, str))
+                        else 0,
                     )
                     meta = metas.get(request_id, {})
 
@@ -307,7 +310,9 @@ class StreamMerger:
                     body["usage"].update(content["usage"])
 
         # Merge deltas into content blocks
-        for index, block in sorted(content_blocks.items()):
+        for index, block in sorted(
+            content_blocks.items(), key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0]
+        ):
             delta_parts = content_block_deltas.get(index, [])
             merged_delta = "".join(delta_parts)
 
@@ -324,7 +329,13 @@ class StreamMerger:
                 block["thinking"] = block.get("thinking", "") + merged_delta
 
         # Build content array in order
-        body["content"] = [block for _, block in sorted(content_blocks.items())]
+        body["content"] = [
+            block
+            for _, block in sorted(
+                content_blocks.items(),
+                key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0],
+            )
+        ]
 
         # Build response record
         response: dict[str, Any] = {
@@ -441,7 +452,7 @@ class StreamMerger:
         if not all_indices:
             all_indices = {0}
 
-        for index in sorted(all_indices):
+        for index in sorted(all_indices, key=lambda x: int(x) if str(x).isdigit() else x):
             message: dict[str, Any] = {
                 "role": choices_role.get(index, "assistant"),
             }
@@ -457,7 +468,10 @@ class StreamMerger:
             tool_calls_data = choices_tool_calls.get(index, {})
             if tool_calls_data:
                 tool_calls_list = []
-                for tc_index, tc_data in sorted(tool_calls_data.items()):
+                for tc_index, tc_data in sorted(
+                    tool_calls_data.items(),
+                    key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0],
+                ):
                     # Merge arguments
                     args_parts = choices_tool_args.get(index, {}).get(tc_index, [])
                     tc_data["function"]["arguments"] = "".join(args_parts)
@@ -566,7 +580,9 @@ class StreamMerger:
 
         # Build the final tool calls list
         tool_calls: list[ToolCall] = []
-        for index, data in sorted(tool_call_data.items()):
+        for index, data in sorted(
+            tool_call_data.items(), key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0]
+        ):
             # Concatenate all JSON fragments for this tool call
             full_json_str = "".join(tool_input_parts.get(index, []))
 

--- a/src/lli/merger.py
+++ b/src/lli/merger.py
@@ -122,7 +122,7 @@ class StreamMerger:
                     request_chunks = sorted(
                         chunks[request_id],
                         key=lambda x: int(x.get("chunk_index", 0))
-                        if isinstance(x.get("chunk_index"), (int, float, str))
+                        if str(x.get("chunk_index", 0)).isdigit()
                         else 0,
                     )
                     meta = metas.get(request_id, {})
@@ -311,7 +311,7 @@ class StreamMerger:
 
         # Merge deltas into content blocks
         for index, block in sorted(
-            content_blocks.items(), key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0]
+            content_blocks.items(), key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0]))
         ):
             delta_parts = content_block_deltas.get(index, [])
             merged_delta = "".join(delta_parts)
@@ -333,7 +333,7 @@ class StreamMerger:
             block
             for _, block in sorted(
                 content_blocks.items(),
-                key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0],
+                key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0])),
             )
         ]
 
@@ -452,7 +452,7 @@ class StreamMerger:
         if not all_indices:
             all_indices = {0}
 
-        for index in sorted(all_indices, key=lambda x: int(x) if str(x).isdigit() else x):
+        for index in sorted(all_indices, key=lambda x: (0, int(x)) if str(x).isdigit() else (1, str(x))):
             message: dict[str, Any] = {
                 "role": choices_role.get(index, "assistant"),
             }
@@ -470,7 +470,7 @@ class StreamMerger:
                 tool_calls_list = []
                 for tc_index, tc_data in sorted(
                     tool_calls_data.items(),
-                    key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0],
+                    key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0])),
                 ):
                     # Merge arguments
                     args_parts = choices_tool_args.get(index, {}).get(tc_index, [])
@@ -581,7 +581,7 @@ class StreamMerger:
         # Build the final tool calls list
         tool_calls: list[ToolCall] = []
         for index, data in sorted(
-            tool_call_data.items(), key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0]
+            tool_call_data.items(), key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0]))
         ):
             # Concatenate all JSON fragments for this tool call
             full_json_str = "".join(tool_input_parts.get(index, []))

--- a/src/lli/merger.py
+++ b/src/lli/merger.py
@@ -311,7 +311,8 @@ class StreamMerger:
 
         # Merge deltas into content blocks
         for index, block in sorted(
-            content_blocks.items(), key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0]))
+            content_blocks.items(),
+            key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0])),
         ):
             delta_parts = content_block_deltas.get(index, [])
             merged_delta = "".join(delta_parts)
@@ -333,7 +334,9 @@ class StreamMerger:
             block
             for _, block in sorted(
                 content_blocks.items(),
-                key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0])),
+                key=lambda x: (
+                    (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0]))
+                ),
             )
         ]
 
@@ -452,7 +455,10 @@ class StreamMerger:
         if not all_indices:
             all_indices = {0}
 
-        for index in sorted(all_indices, key=lambda x: (0, int(x)) if str(x).isdigit() else (1, str(x))):
+        for index in sorted(
+            all_indices,
+            key=lambda x: (0, int(x)) if str(x).isdigit() else (1, str(x)),
+        ):
             message: dict[str, Any] = {
                 "role": choices_role.get(index, "assistant"),
             }
@@ -581,7 +587,8 @@ class StreamMerger:
         # Build the final tool calls list
         tool_calls: list[ToolCall] = []
         for index, data in sorted(
-            tool_call_data.items(), key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0]))
+            tool_call_data.items(),
+            key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0])),
         ):
             # Concatenate all JSON fragments for this tool call
             full_json_str = "".join(tool_input_parts.get(index, []))

--- a/src/lli/server.py
+++ b/src/lli/server.py
@@ -449,7 +449,15 @@ def _build_session_cache_entry(session_dir: Path) -> SessionCacheEntry:
 
     started_at = perf_counter()
 
-    for file_path in sorted(session_dir.glob("*.json")):
+    def _numeric_key(file_path: Path) -> tuple[int, str]:
+        """Extract a numeric key from a filename for natural sorting."""
+        name = file_path.name
+        match = re.match(r"^(\d+)", name)
+        if match:
+            return int(match.group(1)), name
+        return 999999, name
+
+    for file_path in sorted(session_dir.glob("*.json"), key=_numeric_key):
         parsed = _parse_session_file(file_path)
         if parsed is None:
             continue
@@ -598,7 +606,10 @@ def _build_session_cache_entry(session_dir: Path) -> SessionCacheEntry:
         id=session_dir.name,
         exchanges=[
             pair_entry.summary or _empty_exchange_summary(sequence_id)
-            for sequence_id, pair_entry in sorted(pair_cache.items())
+            for sequence_id, pair_entry in sorted(
+                pair_cache.items(),
+                key=lambda x: int(x[0]) if x[0].isdigit() else x[0],
+            )
         ],
     )
     try:

--- a/src/lli/server.py
+++ b/src/lli/server.py
@@ -608,7 +608,7 @@ def _build_session_cache_entry(session_dir: Path) -> SessionCacheEntry:
             pair_entry.summary or _empty_exchange_summary(sequence_id)
             for sequence_id, pair_entry in sorted(
                 pair_cache.items(),
-                key=lambda x: int(x[0]) if x[0].isdigit() else x[0],
+                key=lambda x: (0, int(x[0])) if x[0].isdigit() else (1, x[0]),
             )
         ],
     )

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -338,7 +338,7 @@ const normalizeExchangePair = (
 
     return {
       id: rawRequest.id || `${fallbackSessionId}-${sequenceId || index + 1}`,
-      sequenceId: sequenceId || String(index + 1).padStart(3, '0'),
+      sequenceId: sequenceId || String(index + 1).padStart(5, '0'),
       timestamp: rawRequest.timestamp || new Date().toISOString(),
       latencyMs: rawResponse?.latency_ms || 0,
       statusCode: rawResponse?.status_code || 0,


### PR DESCRIPTION
## Problem

When a session has 1000+ requests, the sorting breaks — after request #1022 it shows #101 instead of #1023. This is because IDs were being sorted lexicographically (string order) instead of numerically.

## Changes

- ****: Use numeric extraction for sorting session files
- ****: Sort request/response pairs by numeric sequence ID
- ****: Sort exchanges by numeric keys in session overview
- ****: Increase zero-padding from 3 to 5 digits (00001) for larger sessions