### PR TITLE
release: v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.9.0] - 2026-04-15
+
+### Added
+
+- **Lazy-load session exchanges** - Session overview now loads exchange data on demand, significantly improving initial load time for sessions with many requests
+- **Virtualized request rendering** - Requests list uses binary search-based virtualization for smooth scrolling with large datasets (#68)
+
+### Fixed
+
+- **Request sorting** - Fixed lexicographic sorting bug that caused incorrect order for sessions with 1000+ requests (e.g. showing #101 after #1022 instead of #1023) (#69)
+- **README typo** - Corrected IP address typo in documentation (127.0.0.0.1 → 127.0.0.1)
+- **Token double-counting** - Fixed total tokens being double-counted when both request and response contain usage metrics
+- **Tool name deduplication** - Prevented duplicate tool names in session summaries
+
+### Changed
+
+- Increased sequence ID zero-padding from 3 to 5 digits to support larger sessions
+
+
 ## [2.8.0] - 2026-03-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Request sorting** - Fixed lexicographic sorting bug that caused incorrect order for sessions with 1000+ requests (e.g. showing #101 after #1022 instead of #1023) (#69)
+- **Request sorting** - Fixed lexicographic sorting bug that caused incorrect order for sessions with 1000+ requests (e.g. showing #2 after #1022 instead of after #1) (#69)
 - **README typo** - Corrected IP address typo in documentation (127.0.0.0.1 → 127.0.0.1)
 - **Token double-counting** - Fixed total tokens being double-counted when both request and response contain usage metrics
 - **Tool name deduplication** - Prevented duplicate tool names in session summaries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-interceptor"
-version = "2.8.0"
+version = "2.9.0"
 description = "Intercept and analyze LLM traffic from AI coding tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/lli/server.py
+++ b/src/lli/server.py
@@ -458,6 +458,7 @@ def _build_session_cache_entry(session_dir: Path) -> SessionCacheEntry:
         return 999999, name
 
     for file_path in sorted(session_dir.glob("*.json"), key=_numeric_key):
+        request_usage = None
         parsed = _parse_session_file(file_path)
         if parsed is None:
             continue


### PR DESCRIPTION
## Changes since v2.8.0

### Added
- Lazy-load session exchanges for faster initial load (#68)
- Virtualized request rendering with binary search (#68)

### Fixed
- Request sorting bug for 1000+ requests (#69)
- README IP address typo
- Token double-counting in session summaries
- Tool name deduplication

### Changed
- Sequence ID padding increased from 3 to 5 digits