### PR TITLE
fix(ui): safeguard exchange.messages.forEach to prevent TypeError when undefined

### DIFF
--- a/ui/src/components/layout/ExchangeDetailsPane.tsx
+++ b/ui/src/components/layout/ExchangeDetailsPane.tsx
@@ -227,7 +227,7 @@ export const ExchangeDetailsPane: React.FC<{
 
     sessionExchanges.forEach((exchange, idx) => {
       const requestIndex = idx + 1;
-      exchange.messages.forEach((message) => pushToolUseFromContent(message.content, requestIndex));
+      (exchange.messages || []).forEach((message) => pushToolUseFromContent(message.content, requestIndex));
       pushToolUseFromContent(exchange.responseContent, requestIndex);
     });
 


### PR DESCRIPTION
When switching sessions in the web UI, the UI would occasionally crash with `TypeError: Cannot read properties of undefined (reading 'forEach')` at `ExchangeDetailsPane.tsx:230`. This occurred because `exchange.messages` could be `undefined` when data parsing from certain providers or under certain edge cases returned payloads missing the `messages` array, breaking the iteration used to push tool use blocks.

This fix safeguards the `.forEach` loop by falling back to an empty array (`(exchange.messages || []).forEach(...)`) if `messages` is missing, which correctly avoids throwing an error and allows the request details to render normally.

---
*PR created automatically by Jules for task [6641880318253368793](https://jules.google.com/task/6641880318253368793) started by @chouzz*