### PR TITLE
fix: render Anthropic thinking blocks

### DIFF
--- a/ui/src/components/chat/MessageContent.tsx
+++ b/ui/src/components/chat/MessageContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Zap } from 'lucide-react';
+import { Brain, Zap } from 'lucide-react';
 import { CopyButton } from '../common/CopyButton';
 import { ToolCallBlock } from './ToolCallBlock';
 
@@ -70,6 +70,36 @@ export const MessageContent: React.FC<{ content: unknown }> = React.memo(({ cont
                 <div className="font-mono text-emerald-800 dark:text-emerald-200/90 whitespace-pre-wrap break-words max-h-[500px] overflow-y-auto custom-scrollbar">
                   {renderedResult}
                 </div>
+              </div>
+            );
+          }
+          if (type === 'thinking') {
+            const thinking = typeof block.thinking === 'string' ? block.thinking : '';
+
+            return (
+              <div
+                key={idx}
+                className="text-xs border-l-2 border-violet-400 pl-3 py-2 my-2 bg-violet-50 dark:bg-violet-950/20 rounded-r overflow-hidden group/thinking"
+              >
+                <div className="font-bold text-violet-600 dark:text-violet-400 text-[10px] uppercase mb-1 flex items-center gap-2">
+                  <Brain size={10} />
+                  Thinking
+                  {thinking && (
+                    <CopyButton
+                      content={thinking}
+                      className="opacity-0 group-hover/thinking:opacity-100"
+                    />
+                  )}
+                </div>
+                {thinking ? (
+                  <div className="text-violet-800 dark:text-violet-200/90 whitespace-pre-wrap break-words max-h-[500px] overflow-y-auto custom-scrollbar italic">
+                    {thinking}
+                  </div>
+                ) : (
+                  <div className="text-violet-700 dark:text-violet-300/80 italic">
+                    No thinking content captured
+                  </div>
+                )}
               </div>
             );
           }

--- a/ui/src/components/chat/MessageContent.tsx
+++ b/ui/src/components/chat/MessageContent.tsx
@@ -74,7 +74,7 @@ export const MessageContent: React.FC<{ content: unknown }> = React.memo(({ cont
             );
           }
           if (type === 'thinking') {
-            const thinking = typeof block.thinking === 'string' ? block.thinking : '';
+            const thinking = typeof block.thinking === 'string' ? block.thinking.trim() : '';
 
             return (
               <div

--- a/ui/src/utils/ui.ts
+++ b/ui/src/utils/ui.ts
@@ -53,8 +53,9 @@ export function extractTextContent(content: unknown): string {
           return `[Tool Result: ${toolUseId}]\n${resultContent}`;
         }
 
-        if (type === 'thinking' && typeof block.thinking === 'string') {
-          return `[Thinking]\n${block.thinking}`;
+        if (type === 'thinking') {
+          const thinking = typeof block.thinking === 'string' ? block.thinking.trim() : '';
+          return thinking ? `[Thinking]\n${thinking}` : '[Thinking]\nNo thinking content captured';
         }
 
         return JSON.stringify(block, null, 2);

--- a/ui/src/utils/ui.ts
+++ b/ui/src/utils/ui.ts
@@ -53,6 +53,10 @@ export function extractTextContent(content: unknown): string {
           return `[Tool Result: ${toolUseId}]\n${resultContent}`;
         }
 
+        if (type === 'thinking' && typeof block.thinking === 'string') {
+          return `[Thinking]\n${block.thinking}`;
+        }
+
         return JSON.stringify(block, null, 2);
       })
       .join('\n\n');


### PR DESCRIPTION
## Summary
- Render Anthropic `thinking` content blocks in chat messages instead of showing `[Unknown Block Type: thinking]`.
- Include thinking block text in the copyable flattened message content.
- Show a graceful placeholder if a thinking block has no captured text.

## Verification
- `npm run build`
- `npm run lint` *(currently fails on pre-existing React Compiler lint issues in `ExchangeDetailsPane.tsx` and `RequestsPane.tsx`, unrelated to this change)*

Fixes #77
