### PR TITLE
fix: show latest sessions first by default

### DIFF
--- a/ui/src/hooks/useSessionListPreferences.ts
+++ b/ui/src/hooks/useSessionListPreferences.ts
@@ -8,8 +8,7 @@ function readInitialSortPreference(): boolean {
   }
 
   try {
-    const storedPreference = window.localStorage.getItem(SORT_ORDER_STORAGE_KEY);
-    return storedPreference === null ? true : storedPreference === 'true';
+    return window.localStorage.getItem(SORT_ORDER_STORAGE_KEY) !== 'false';
   } catch (error) {
     console.error('Failed to read session sort preference', error);
     return true;

--- a/ui/src/hooks/useSessionListPreferences.ts
+++ b/ui/src/hooks/useSessionListPreferences.ts
@@ -4,14 +4,15 @@ const SORT_ORDER_STORAGE_KEY = 'lli.sessions.sortNewestFirst';
 
 function readInitialSortPreference(): boolean {
   if (typeof window === 'undefined') {
-    return false;
+    return true;
   }
 
   try {
-    return window.localStorage.getItem(SORT_ORDER_STORAGE_KEY) === 'true';
+    const storedPreference = window.localStorage.getItem(SORT_ORDER_STORAGE_KEY);
+    return storedPreference === null ? true : storedPreference === 'true';
   } catch (error) {
     console.error('Failed to read session sort preference', error);
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary
- Default the Sessions view sort preference to newest-first for first-time users.
- Preserve any existing localStorage sort preference so users who already chose oldest-first keep that setting.
- Keep the fallback selection aligned with the visible newest-first ordering.

## Verification
- `npm run build`

Fixes #79
