### PR TITLE
feat: render Anthropic content blocks

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -58,7 +58,7 @@ const App: React.FC = () => {
     if (!currentSession) return [];
     if (!systemPromptFilter) return currentSession.exchanges;
     return currentSession.exchanges.filter(
-      (ex) => stringToColor(ex.systemPromptKey || ex.systemPrompt || '') === systemPromptFilter
+      (ex) => stringToColor(ex.systemPromptKey) === systemPromptFilter
     );
   }, [currentSession, systemPromptFilter]);
 

--- a/ui/src/components/layout/ExchangeDetailsPane.tsx
+++ b/ui/src/components/layout/ExchangeDetailsPane.tsx
@@ -123,6 +123,13 @@ export const ExchangeDetailsPane: React.FC<{
     [currentExchange?.rawResponse]
   );
 
+  const systemPromptText = useMemo(
+    () => (currentExchange?.systemPrompt != null ? extractTextContent(currentExchange.systemPrompt).trim() : ''),
+    [currentExchange?.systemPrompt]
+  );
+
+  const hasSystemPrompt = systemPromptText.length > 0;
+
   const shouldComputeStats = activeTab === 'stats' && sessionExchanges.length > 0;
   const isExchangeReady = !!currentExchange?.hasFullDetails && !isLoadingExchangeDetails;
 
@@ -402,11 +409,11 @@ export const ExchangeDetailsPane: React.FC<{
                     <span className="w-12 h-[1px] bg-gray-200 dark:bg-slate-800"></span>
                   </div>
 
-                  {currentExchange.systemPrompt != null && (
+                  {hasSystemPrompt && currentExchange.systemPrompt != null && (
                     <ChatBubble message={{ role: 'system', content: currentExchange.systemPrompt }} />
                   )}
 
-                  {currentExchange.messages.length === 0 && currentExchange.systemPrompt == null && (
+                  {currentExchange.messages.length === 0 && !hasSystemPrompt && (
                     <div className="text-sm text-slate-500 dark:text-slate-600 italic text-center py-8 bg-gray-50 dark:bg-slate-900/20 rounded-lg border border-dashed border-gray-200 dark:border-slate-800">
                       No prior context messages. This appears to be the start of a conversation.
                     </div>
@@ -455,17 +462,17 @@ export const ExchangeDetailsPane: React.FC<{
                         System Instruction
                       </span>
                     </div>
-                    {currentExchange.systemPrompt != null && (
+                    {hasSystemPrompt && (
                       <CopyButton
-                        content={extractTextContent(currentExchange.systemPrompt)}
+                        content={systemPromptText}
                         className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700"
                       />
                     )}
                   </div>
                   <div className="p-6 overflow-x-auto bg-gray-50 dark:bg-transparent">
-                    {currentExchange.systemPrompt != null ? (
+                    {hasSystemPrompt ? (
                       <pre className="text-sm font-mono text-slate-800 dark:text-slate-300 whitespace-pre-wrap leading-relaxed selection:bg-red-200 dark:selection:bg-red-900/30">
-                        {extractTextContent(currentExchange.systemPrompt)}
+                        {systemPromptText}
                       </pre>
                     ) : (
                       <div className="text-gray-500 dark:text-slate-500 italic text-sm text-center py-8">

--- a/ui/src/components/layout/ExchangeDetailsPane.tsx
+++ b/ui/src/components/layout/ExchangeDetailsPane.tsx
@@ -28,7 +28,7 @@ import {
   YAxis,
 } from 'recharts';
 import type { NormalizedExchange } from '../../types';
-import { safeJSONStringify } from '../../utils/ui';
+import { extractTextContent, safeJSONStringify } from '../../utils/ui';
 import { ChatBubble } from '../chat/ChatBubble';
 import { CopyButton } from '../common/CopyButton';
 import { JSONViewer } from '../common/JSONViewer';
@@ -402,11 +402,11 @@ export const ExchangeDetailsPane: React.FC<{
                     <span className="w-12 h-[1px] bg-gray-200 dark:bg-slate-800"></span>
                   </div>
 
-                  {currentExchange.systemPrompt && (
+                  {currentExchange.systemPrompt != null && (
                     <ChatBubble message={{ role: 'system', content: currentExchange.systemPrompt }} />
                   )}
 
-                  {currentExchange.messages.length === 0 && !currentExchange.systemPrompt && (
+                  {currentExchange.messages.length === 0 && currentExchange.systemPrompt == null && (
                     <div className="text-sm text-slate-500 dark:text-slate-600 italic text-center py-8 bg-gray-50 dark:bg-slate-900/20 rounded-lg border border-dashed border-gray-200 dark:border-slate-800">
                       No prior context messages. This appears to be the start of a conversation.
                     </div>
@@ -455,17 +455,17 @@ export const ExchangeDetailsPane: React.FC<{
                         System Instruction
                       </span>
                     </div>
-                    {currentExchange.systemPrompt && (
+                    {currentExchange.systemPrompt != null && (
                       <CopyButton
-                        content={currentExchange.systemPrompt}
+                        content={extractTextContent(currentExchange.systemPrompt)}
                         className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700"
                       />
                     )}
                   </div>
                   <div className="p-6 overflow-x-auto bg-gray-50 dark:bg-transparent">
-                    {currentExchange.systemPrompt ? (
+                    {currentExchange.systemPrompt != null ? (
                       <pre className="text-sm font-mono text-slate-800 dark:text-slate-300 whitespace-pre-wrap leading-relaxed selection:bg-red-200 dark:selection:bg-red-900/30">
-                        {currentExchange.systemPrompt}
+                        {extractTextContent(currentExchange.systemPrompt)}
                       </pre>
                     ) : (
                       <div className="text-gray-500 dark:text-slate-500 italic text-sm text-center py-8">

--- a/ui/src/components/layout/RequestsPane.tsx
+++ b/ui/src/components/layout/RequestsPane.tsx
@@ -64,7 +64,7 @@ export const RequestsPane: React.FC<{
   const exchangeColors = useMemo(() => {
     const colors: Record<string, string> = {};
     filteredExchanges.forEach((exchange) => {
-      colors[exchange.id] = stringToColor(exchange.systemPromptKey || exchange.systemPrompt || '');
+      colors[exchange.id] = stringToColor(exchange.systemPromptKey);
     });
     return colors;
   }, [filteredExchanges]);

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -118,7 +118,7 @@ export interface NormalizedExchange {
   hasFullDetails: boolean;
 
   // Grouped Data
-  systemPrompt?: string; // Extracted system prompt
+  systemPrompt?: unknown; // Extracted system prompt; can be text or provider content blocks
   messages: NormalizedMessage[]; // The conversation context sent TO the model
   tools?: NormalizedTool[]; // Tools defined in the request
 

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -95,7 +95,7 @@ const normalizeUsageMetrics = (rawUsage: unknown) => {
 /**
  * Convert OpenAI system content (string/array/object) to readable string.
  */
-const normalizeOpenAISystemContent = (content: unknown): string => {
+const extractProviderTextContent = (content: unknown): string => {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
     return content
@@ -131,7 +131,7 @@ const normalizeOpenAIRequest = (
   const system =
     systemMessages.length > 0
       ? systemMessages
-          .map((m) => (isRecord(m) ? normalizeOpenAISystemContent(m.content) : ''))
+          .map((m) => (isRecord(m) ? extractProviderTextContent(m.content) : ''))
           .filter(Boolean)
           .join('\n')
       : undefined;
@@ -220,23 +220,24 @@ const normalizeOpenAIRequest = (
  */
 const normalizeAnthropicRequest = (
   body: unknown
-): { system: string | undefined; messages: NormalizedMessage[]; tools: NormalizedTool[]; model: string } => {
+): { system: unknown; messages: NormalizedMessage[]; tools: NormalizedTool[]; model: string } => {
   if (!isRecord(body)) return { system: undefined, messages: [], tools: [], model: 'unknown' };
 
   const model = asString(body.model, 'unknown-model');
 
-  // System prompt can be a string or array of objects in Anthropic
-  let system: string | undefined = undefined;
-  if (typeof body.system === 'string') {
-    system = body.system;
-  } else if (Array.isArray(body.system)) {
-    system = body.system
-      .map((s) => (isRecord(s) ? asString(s.text) : ''))
-      .filter(Boolean)
-      .join('\n');
-  }
+  // System prompt can be a string or an array of content blocks in Anthropic.
+  // Preserve arrays so the chat/system views can render each block separately.
+  const system: unknown =
+    typeof body.system === 'string' || Array.isArray(body.system) ? body.system : undefined;
 
-  const messages: NormalizedMessage[] = Array.isArray(body.messages) ? (body.messages as NormalizedMessage[]) : [];
+  const messages: NormalizedMessage[] = Array.isArray(body.messages)
+    ? body.messages
+        .filter((message): message is Record<string, unknown> => isRecord(message))
+        .map((message) => ({
+          role: asString(message.role, 'user') as NormalizedMessage['role'],
+          content: message.content,
+        }))
+    : [];
 
   const tools: NormalizedTool[] = Array.isArray(body.tools)
     ? body.tools
@@ -335,6 +336,7 @@ const normalizeExchangePair = (
     }
 
     const { system, messages, tools, model } = normalized;
+    const systemPromptKey = extractProviderTextContent(system);
 
     return {
       id: rawRequest.id || `${fallbackSessionId}-${sequenceId || index + 1}`,
@@ -343,7 +345,7 @@ const normalizeExchangePair = (
       latencyMs: rawResponse?.latency_ms || 0,
       statusCode: rawResponse?.status_code || 0,
       model,
-      systemPromptKey: system || '',
+      systemPromptKey,
       toolNames: [],
       hasFullDetails: true,
       systemPrompt: system,


### PR DESCRIPTION
## Summary
- Preserve Anthropic `system` arrays as content blocks instead of flattening them during normalization.
- Render system content blocks in Chat view using the existing block renderer, so separate Anthropic system blocks remain visually distinct.
- Keep system prompt grouping/filtering and System tab copy behavior stable by deriving a text key from provider content blocks.
- Normalize Anthropic messages defensively while preserving their content arrays for multi-block rendering.

## Verification
- `npm run build`
- `npm run lint` *(fails on pre-existing React Compiler lint issues in `ExchangeDetailsPane.tsx` and `RequestsPane.tsx`, unrelated to this change)*

Fixes #81
