### PR TITLE
chore: release v2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.3] - 2026-06-02
+
+### Changed
+
+- Updated package version for the next release.
+- Updated release changelog.
 
 ## [2.9.2] - 2026-04-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-interceptor"
-version = "2.9.2"
+version = "2.9.3"
 description = "Intercept and analyze LLM traffic from AI coding tools"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Bump package version to 2.9.3
- Add 2.9.3 changelog entry

## Checks

- `uv run ruff check src/`
- `uv run pytest tests/ -v --tb=short`
- `npm ci --prefix ui`
- `npm run build --prefix ui`
- `uv build`
