### PR TITLE
fix(ui): remove excessive spacing between request list items

### DIFF
--- a/ui/src/components/layout/RequestsPane.tsx
+++ b/ui/src/components/layout/RequestsPane.tsx
@@ -105,14 +105,14 @@ export const RequestsPane: React.FC<{
   }, [filteredExchanges, isCollapsed]);
 
   const handleItemHeightChange = useCallback((exchangeId: string, height: number) => {
-    const nextHeight = Math.max(Math.ceil(height), estimatedRowHeight);
+    const nextHeight = Math.ceil(height);
     if (itemHeightsRef.current[exchangeId] === nextHeight) {
       return;
     }
 
     itemHeightsRef.current[exchangeId] = nextHeight;
     setHeightVersion((version) => version + 1);
-  }, [estimatedRowHeight]);
+  }, []);
 
   // Memoize computed values
   const requestCount = useMemo(() => filteredExchanges.length, [filteredExchanges.length]);


### PR DESCRIPTION
## Problem

The Requests list in the UI showed large blank gaps between consecutive request items. Each item\'s actual content height (~90-110px) was shorter than the `estimatedRowHeight` (156px), but the measured height was being forced up to the estimated value, reserving unused vertical space.

## Root Cause

In `RequestsPane.tsx`, `handleItemHeightChange` clamped each item\'s measured height to a minimum of `estimatedRowHeight`:

```js
const nextHeight = Math.max(Math.ceil(height), estimatedRowHeight);
```

Since rows are absolutely positioned (`top = previous bottom`), reserving 156px for content that is only ~90px tall produced a ~60px blank gap between every pair of requests.

`estimatedRowHeight` is already correctly used as the initial fallback for unmeasured items (line 139), so it should not also act as a minimum bound on measured heights.

## Fix

Use the actual measured height directly:

```js
const nextHeight = Math.ceil(height);
```

The dependency on `estimatedRowHeight` was removed from the `useCallback` since it is no longer referenced in the callback body.