### PR TITLE
fix(ui): preserve measured request heights across detail merges

### DIFF
--- a/ui/src/components/layout/RequestsPane.tsx
+++ b/ui/src/components/layout/RequestsPane.tsx
@@ -69,6 +69,14 @@ export const RequestsPane: React.FC<{
     return colors;
   }, [filteredExchanges]);
 
+  // Stable identity key for the exchange list so that lazy detail merges (which
+  // create a new array reference) do NOT reset measured heights. Reset only when
+  // the actual set of exchanges changes (session switch, filter, new request).
+  const exchangeListKey = useMemo(
+    () => filteredExchanges.map((exchange) => exchange.id).join('|'),
+    [filteredExchanges]
+  );
+
   // Memoize callback functions to prevent unnecessary re-renders
   const handleToggleCollapse = useCallback(() => {
     setIsCollapsed(!isCollapsed);
@@ -102,7 +110,7 @@ export const RequestsPane: React.FC<{
     setHeightVersion((version) => version + 1);
     setScrollTop(0);
     scrollContainerRef.current?.scrollTo({ top: 0, behavior: 'auto' });
-  }, [filteredExchanges, isCollapsed]);
+  }, [exchangeListKey, isCollapsed]);
 
   const handleItemHeightChange = useCallback((exchangeId: string, height: number) => {
     const nextHeight = Math.ceil(height);


### PR DESCRIPTION
## Problem

Despite the spacing fix in #87, large gaps still reappear between request list items shortly after selecting a session. The items briefly render close together, then gaps open up and persist.

## Root Cause

The height-reset effect in `RequestsPane.tsx` depended on `filteredExchanges` (an **array reference**). That reference changes not only when switching sessions/filters, but also whenever an exchange's full details are lazily fetched and merged via `mergeExchangeDetail` in `useSessions.ts` (which builds a new `currentSession` → new `exchanges` array).

The resulting sequence:
1. Session overview loads → items render → `ResizeObserver` measures real heights (~90px) → items display **tightly packed** (the brief correct moment).
2. Auto-selected exchange's details finish loading → `mergeExchangeDetail` → new `filteredExchanges` reference → **reset effect fires** → `itemHeightsRef.current = {}` clears every measured height → all items fall back to `estimatedRowHeight` (156px) → **gaps appear**.
3. `ResizeObserver` does not re-fire (size unchanged), so heights stay at 156 → gaps persist.

## Fix

Derive a stable `exchangeListKey` from the exchange IDs and use it as the reset-effect dependency instead of the array reference. The reset now only fires when the **actual set of exchanges changes** (session switch, filter, new request), never when detail data is merged into existing exchanges.

```diff
+ const exchangeListKey = useMemo(
+   () => filteredExchanges.map((exchange) => exchange.id).join('|'),
+   [filteredExchanges]
+ );
  useEffect(() => {
    ...
- }, [filteredExchanges, isCollapsed]);
+ }, [exchangeListKey, isCollapsed]);
```

## Verification

- `npm run build` (tsc + vite) passes.
- `npm run lint`: no new errors/warnings introduced (pre-existing `offset` reassign lint remains unchanged).